### PR TITLE
Introduce Wireloft web UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p /downloads /config /usr/local/bin /app/cache /tmp/yt-dlp-tmp \
 # Install the package
 COPY pyproject.toml poetry.lock poetry.toml /app/
 COPY dailywire_downloader/__init__.py /app/dailywire_downloader/__init__.py
+COPY wireloft_web/__init__.py /app/wireloft_web/__init__.py
 RUN cd /app && \
     poetry install
 ENV DW_CONFIG_FILE="/config/config.yml"
@@ -40,6 +41,8 @@ ENV DW_DOWNLOAD_DIR="/downloads"
 
 # Copy remaining package files (we do this here to prevent poetry install from re- running for every change in the package
 COPY ./dailywire_downloader/ /app/dailywire_downloader/
+COPY ./wireloft_web/ /app/wireloft_web/
+COPY ./frontend/ /app/frontend/
 
 # Copy scripts to /usr/local/bin
 COPY ./scripts/ /usr/local/bin/
@@ -57,4 +60,4 @@ VOLUME ["/config","/downloads"]
 
 # Entrypoint sets up cron, then CMD runs it
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["sh", "-c", "cron -f & tail -f /var/log/cron.log"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 > This project was made primarily for personal use. Im sharing it publicly in the hopes it might be useful to some. If you run into issues, let me know, but I might not always respond very quickly 
 
-# DailyWire Show Downloader
+# Wireloft
 
-This is a simple project made to download premium shows from The Daily Wire website using browser cookies.<br>
+Wireloft is a simple project to manage and download premium shows from The Daily Wire website using a web interface.<br>
 For this to work, an active premium subscription to The Daily Wire is required.
 
 My main personal use for this is to download the episodes to a directory read by my Audiobookshelf instance, which I then use to create a private RSS feed from the episodes.
@@ -15,8 +15,15 @@ My main personal use for this is to download the episodes to a directory read by
 - Can extract video descriptions and save them as .nfo files for Audiobookshelf compatibility
 - Ensures filenames only use ASCII characters for maximum compatibility
 - Configurable download schedule via cron
+- Web interface built with React served by gunicorn
 
 ## Quick Start
+
+Wireloft exposes a small React interface with three pages:
+
+1. **Home** – overview of your library size, downloaded files and shows.
+2. **Shows** – list of all shows with their download size. Each show can be edited individually.
+3. **Settings** – edit global settings for the downloader.
 
 ### Using Docker
 
@@ -31,10 +38,11 @@ My main personal use for this is to download the episodes to a directory read by
 
 3. Run the Docker container:
    ```bash
-   docker run -d \
-     -v $(pwd)/config:/config:ro \
-     -v $(pwd)/downloads:/downloads \
-     ghcr.io/samuelvisser/dailywire-downloader:latest
+  docker run -d \
+    -v $(pwd)/config:/config:ro \
+    -v $(pwd)/downloads:/downloads \
+    -p 8000:8000 \
+    ghcr.io/samuelvisser/wireloft:latest
    ```
 
 ### Using Python Package
@@ -140,13 +148,14 @@ You can also set these paths using environment variables:
 The easiest way to get started is to use the pre-built image from GitHub Container Registry:
 
 ```bash
-docker pull ghcr.io/samuelvisser/dailywire-downloader:latest
+docker pull ghcr.io/samuelvisser/wireloft:latest
 
 docker run -d \
   -v $(pwd)/config:/config:ro \
   -v $(pwd)/downloads:/downloads \
-  --name dailywire-downloader \
-  ghcr.io/samuelvisser/dailywire-downloader:latest
+  -p 8000:8000 \
+  --name wireloft \
+  ghcr.io/samuelvisser/wireloft:latest
 ```
 
 ### How the Docker container works
@@ -158,26 +167,26 @@ When the container starts:
 ### Viewing logs
 To view the logs from the Docker container:
 ```bash
-docker logs -f dailywire-downloader
+docker logs -f wireloft
 ```
 
 ### Running a manual download
 To trigger a download manually:
 ```bash
-docker exec dailywire-downloader dailywire-downloader
+docker exec wireloft dailywire-downloader
 ```
 
 ### Building your own Docker image
 If you want to build the image yourself:
 
 ```bash
-docker build -t dailywire-downloader .
+docker build -t wireloft .
 
 docker run -d \
   -v $(pwd)/config:/config:ro \
   -v $(pwd)/downloads:/downloads \
-  --name dailywire-downloader \
-  dailywire-downloader
+  --name wireloft \
+  wireloft
 ```
 
 ## Development
@@ -225,11 +234,11 @@ dailywire-downloader
 
 ### Push new update to github registry (dev only)
 ```bash
-docker build -t dailywire-downloader .
+docker build -t wireloft .
 
 echo ACCESS_TOKEN | docker login ghcr.io -u samuelvisser --password-stdin
 
-docker tag dailywire-downloader ghcr.io/samuelvisser/dailywire-downloader:latest
+docker tag wireloft ghcr.io/samuelvisser/wireloft:latest
 
-docker push ghcr.io/samuelvisser/dailywire-downloader:latest
+docker push ghcr.io/samuelvisser/wireloft:latest
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
-  dailywire:
+  wireloft:
     build: .
-    container_name: dailywire-downloader
+    container_name: wireloft
     restart: no
     volumes:
       - ./config:/config
       - ./downloads:/downloads
     environment:
       - TZ=Europe/Amsterdam
+    ports:
+      - "8000:8000"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Wireloft</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-router-dom@5/umd/react-router-dom.min.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 20px; }
+      nav a { margin-right: 10px; }
+      table { border-collapse: collapse; }
+      th, td { padding: 4px 8px; border: 1px solid #ccc; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const { BrowserRouter, Switch, Route, Link, useParams } = ReactRouterDOM;
+
+      function useFetch(url) {
+        const [data, setData] = React.useState(null);
+        React.useEffect(() => {
+          fetch(url).then(r => r.json()).then(setData);
+        }, [url]);
+        return data;
+      }
+
+      function Home() {
+        const data = useFetch('/api/overview');
+        if (!data) return <div>Loading...</div>;
+        return (
+          <div>
+            <h2>Overview</h2>
+            <p>Library size: {data.library_size} bytes</p>
+            <p>Downloaded files: {data.files}</p>
+            <p>Shows added: {data.shows}</p>
+          </div>
+        );
+      }
+
+      function Shows() {
+        const shows = useFetch('/api/shows');
+        if (!shows) return <div>Loading...</div>;
+        return (
+          <div>
+            <h2>Shows</h2>
+            <table>
+              <thead>
+                <tr><th>Name</th><th>Size (bytes)</th><th></th></tr>
+              </thead>
+              <tbody>
+                {shows.map(s => (
+                  <tr key={s.name}>
+                    <td>{s.name}</td>
+                    <td>{s.size}</td>
+                    <td><Link to={`/shows/${s.name}`}>Edit</Link></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      }
+
+      function ShowEdit() {
+        const { name } = useParams();
+        const data = useFetch(`/api/shows/${name}`);
+        const [text, setText] = React.useState('');
+        React.useEffect(() => { if (data) setText(JSON.stringify(data.config, null, 2)); }, [data]);
+        if (!data) return <div>Loading...</div>;
+        const save = () => {
+          fetch(`/api/shows/${name}`, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify({config: JSON.parse(text)})})
+            .then(() => alert('Saved'));
+        };
+        return (
+          <div>
+            <h2>Edit {name}</h2>
+            <p>Total size: {data.size} bytes</p>
+            <textarea rows="20" cols="80" value={text} onChange={e=>setText(e.target.value)} />
+            <div><button onClick={save}>Save</button></div>
+          </div>
+        );
+      }
+
+      function Settings() {
+        const data = useFetch('/api/settings');
+        const [text, setText] = React.useState('');
+        React.useEffect(() => { if (data) setText(JSON.stringify(data, null, 2)); }, [data]);
+        if (!data) return <div>Loading...</div>;
+        const save = () => {
+          fetch('/api/settings', {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify({settings: JSON.parse(text)})})
+            .then(() => alert('Saved'));
+        };
+        return (
+          <div>
+            <h2>Settings</h2>
+            <textarea rows="20" cols="80" value={text} onChange={e=>setText(e.target.value)} />
+            <div><button onClick={save}>Save</button></div>
+          </div>
+        );
+      }
+
+      function App() {
+        return (
+          <BrowserRouter>
+            <nav>
+              <Link to="/">Home</Link>
+              <Link to="/shows">Shows</Link>
+              <Link to="/settings">Settings</Link>
+            </nav>
+            <Switch>
+              <Route exact path="/" component={Home} />
+              <Route exact path="/shows" component={Shows} />
+              <Route path="/shows/:name" component={ShowEdit} />
+              <Route path="/settings" component={Settings} />
+            </Switch>
+          </BrowserRouter>
+        );
+      }
+
+      ReactDOM.render(<App />, document.getElementById('root'));
+    </script>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,27 @@
 [tool.poetry]
-name = "dailywire-downloader"
+name = "wireloft"
 version = "0.1.0"
-description = "A tool to download premium shows from the DailyWire website"
+description = "Wireloft - manage and download DailyWire shows"
 authors = ["Samuël Visser <samuvisser@gmail.com>"]
-packages = [{include = "dailywire_downloader"}]
+packages = [
+    {include = "dailywire_downloader"},
+    {include = "wireloft_web"}
+]
 
 [tool.poetry.dependencies]
 python = "~3.13"
 pyyaml = "^6.0"
 yt-dlp = { git = "https://github.com/yt-dlp/yt-dlp.git", rev = "311bb3b" }
+fastapi = "^0.110"
+uvicorn = "^0.24"
+gunicorn = "^21.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
 
 [tool.poetry.scripts]
 dailywire-downloader = "dailywire_downloader.__main__:main"
+wireloft-api = "wireloft_web.app:app"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -38,5 +38,7 @@ crontab "$CRON_FILE"
 echo "$(date '+%Y-%m-%d %H:%M:%S'): Initial download on startup"
 $DOWNLOAD_CMD
 
-# Hand off to CMD (i.e. cron -f)
-exec "$@"
+# Start cron in foreground and run gunicorn alongside
+cron
+/usr/local/bin/run_gunicorn.sh &
+exec tail -f /var/log/cron.log

--- a/scripts/run_gunicorn.sh
+++ b/scripts/run_gunicorn.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec gunicorn wireloft_web.app:app -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000

--- a/wireloft_web/app.py
+++ b/wireloft_web/app.py
@@ -1,0 +1,118 @@
+import os
+import yaml
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+# Paths
+CONFIG_FILE = os.environ.get("DW_CONFIG_FILE", os.path.join(os.getcwd(), "config", "config.yml"))
+COOKIES_FILE = os.environ.get("DW_COOKIES_FILE", os.path.join(os.getcwd(), "config", "cookies.txt"))
+DOWNLOAD_DIR = os.environ.get("DW_DOWNLOAD_DIR", os.path.join(os.getcwd(), "downloads"))
+
+app = FastAPI(title="Wireloft")
+
+FRONTEND_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend")
+
+@app.get("/")
+def index():
+    return FileResponse(os.path.join(FRONTEND_DIR, "index.html"))
+
+app.mount("/static", StaticFiles(directory=FRONTEND_DIR), name="static")
+
+
+def _load_config():
+    with open(CONFIG_FILE) as f:
+        return yaml.safe_load(f)
+
+def _save_config(cfg):
+    with open(CONFIG_FILE, "w") as f:
+        yaml.safe_dump(cfg, f)
+
+def _show_path(name):
+    return os.path.join(DOWNLOAD_DIR, name)
+
+def _dir_size(path):
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for f in files:
+            try:
+                total += os.path.getsize(os.path.join(root, f))
+            except FileNotFoundError:
+                pass
+    return total
+
+
+def _library_overview():
+    cfg = _load_config()
+    shows = cfg.get("shows", [])
+    show_sizes = {s["name"]: _dir_size(_show_path(s["name"])) for s in shows}
+    total_size = sum(show_sizes.values())
+    file_count = 0
+    for _, _, files in os.walk(DOWNLOAD_DIR):
+        file_count += len(files)
+    return {
+        "library_size": total_size,
+        "files": file_count,
+        "shows": len(shows),
+    }
+
+
+@app.get("/api/overview")
+def api_overview():
+    return _library_overview()
+
+
+@app.get("/api/shows")
+def api_shows():
+    cfg = _load_config()
+    result = []
+    for s in cfg.get("shows", []):
+        size = _dir_size(_show_path(s["name"]))
+        result.append({"name": s["name"], "url": s.get("url", ""), "size": size})
+    return result
+
+
+class ShowConfig(BaseModel):
+    config: dict
+
+
+@app.get("/api/shows/{name}")
+def api_show(name: str):
+    cfg = _load_config()
+    for s in cfg.get("shows", []):
+        if s.get("name") == name:
+            size = _dir_size(_show_path(name))
+            return {"name": name, "size": size, "config": s}
+    raise HTTPException(status_code=404, detail="Show not found")
+
+
+@app.put("/api/shows/{name}")
+def api_update_show(name: str, data: ShowConfig):
+    cfg = _load_config()
+    for idx, s in enumerate(cfg.get("shows", [])):
+        if s.get("name") == name:
+            cfg["shows"][idx] = data.config
+            _save_config(cfg)
+            return {"status": "ok"}
+    raise HTTPException(status_code=404, detail="Show not found")
+
+
+@app.get("/api/settings")
+def api_settings():
+    cfg = _load_config()
+    cfg.pop("shows", None)
+    return cfg
+
+
+class SettingsModel(BaseModel):
+    settings: dict
+
+
+@app.put("/api/settings")
+def api_update_settings(data: SettingsModel):
+    cfg = _load_config()
+    for k, v in data.settings.items():
+        cfg[k] = v
+    _save_config(cfg)
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- rename project to Wireloft
- add FastAPI app with endpoints for library overview, show management and settings
- serve React single-page UI
- run the server with gunicorn alongside cron
- update Docker packaging and docs for new name

## Testing
- `pytest -q`